### PR TITLE
Revert lesson template change from 8493e759

### DIFF
--- a/themes/tecsaladeaula/templates/lesson.html
+++ b/themes/tecsaladeaula/templates/lesson.html
@@ -18,6 +18,10 @@ wrapper-course-lesson
 
 {% block content %}
 
-{% include "_lesson-riw.html"  with lesson=lesson %}
+{% if lesson.course.name == "Read in Web" %}
+  {% include "_lesson-riw.html"  with lesson=lesson %}
+{% else %}
+  {% include "_lesson-regular-course.html"  with lesson=lesson %}
+{% endif %}
 
 {% endblock %}


### PR DESCRIPTION
This if is needed to show a different template for regular lessons and another for the grammar lessons. This should be implemented in a robust way, maybe creating different lesson types but this is the simplest way to run it for the current class.